### PR TITLE
use option.text value when valuesUseText option is set

### DIFF
--- a/src/docs/pages/options.vue
+++ b/src/docs/pages/options.vue
@@ -189,16 +189,16 @@ export default Vue.extend({
       valuesUseText: true,
       data: [
         {
-          innerHTML: '<b>Bold Text</b>',
+          innerHTML: '<b>Bold Text</b><br /><small>additional content</small>',
           text: 'Bold Text',
           value: 'bold text'
         },
         {
-          innerHTML: '<i>Slim Select you are awesome</i>',
+          innerHTML: '<i>Slim Select you are awesome</i><br /><small>additional content</small>',
           text: 'Slim Select awesome'
         },
         {
-          innerHTML: '<div style="border: solid 1px #666666;">Border</div>',
+          innerHTML: '<div style="border: solid 1px #666666;">Border<br /><small>additional content</small></div>',
           text: 'Border',
           value: 'border'
         }
@@ -210,16 +210,16 @@ export default Vue.extend({
       valuesUseText: true,
       data: [
         {
-          innerHTML: '<b>Bold Text</b>',
+          innerHTML: '<b>Bold Text</b><br /><small>additional content</small>',
           text: 'Bold Text',
           value: 'bold text'
         },
         {
-          innerHTML: '<i>Slim Select you are awesome</i>',
+          innerHTML: '<i>Slim Select you are awesome</i><br /><small>additional content</small>',
           text: 'Slim Select awesome'
         },
         {
-          innerHTML: '<div style="border: solid 1px #666666;">Border</div>',
+          innerHTML: '<div style="border: solid 1px #666666;">Border<br /><small>additional content</small></div>',
           text: 'Border',
           value: 'border'
         }
@@ -748,13 +748,6 @@ export default Vue.extend({
         <select id="selectInnerHTMLSingle"></select>
         <select id="selectInnerHTMLMulti" multiple></select>
       </div>
-      <div class="set-content" style="padding: 16px 0 0 0;">
-        <h4>Use text for selected values</h4>
-      </div>
-      <div class="set-content">
-        <select id="selectInnerHTMLSingleText"></select>
-        <select id="selectInnerHTMLMultiText" multiple></select>
-      </div>
 
       <pre>
         <code class="language-javascript">
@@ -772,6 +765,46 @@ export default Vue.extend({
           })
         </code>
       </pre>
+
+      <div class="set-content" style="padding: 16px 0 0 0;">
+        <h4>Use text for selected values</h4>
+      </div>       
+      <p>
+        With the <code>valuesUseText</code> option, you can use rich information in the select dropdown, but show only a single label in the selected value(s).
+      </p>
+      <div class="set-content">
+        <select id="selectInnerHTMLSingleText"></select>
+        <select id="selectInnerHTMLMultiText" multiple></select>
+      </div>
+
+      <pre>
+        <code class="language-javascript">
+          <select id="select-innerHTML"></select>
+
+          var select = new SlimSelect({
+          select: '#select-innerHTML-text',
+          valuesUseText: true,
+          data: [
+            {
+              innerHTML: '<b>Bold Text</b><br /><small>additional content</small>',
+              text: 'Bold Text',
+              value: 'bold text'
+            },
+            {
+              innerHTML: '<i>Slim Select you are awesome</i><br /><small>additional content</small>',
+              text: 'Slim Select awesome'
+            },
+            {
+              innerHTML: '<div style="border: solid 1px #666666;">Border<br /><small>additional content</small></div>',
+              text: 'Border',
+              value: 'border'
+            }
+          ]
+        })
+        </code>
+      </pre>
+
+
     </div>
 
     <div class="content">

--- a/src/slim-select/data.ts
+++ b/src/slim-select/data.ts
@@ -114,7 +114,10 @@ export class Data {
     return {
       id: (option.dataset ? option.dataset.id : false) || String(Math.floor(Math.random() * 100000000)),
       value: option.value,
-      text: option.text,
+      // if explicitly defined, we stored text in a custom data attribute
+      // note that due to constantly re-constructing data from nodes and vice-versa,
+      // text will now be explicitly defined on the next pass.
+      text: option.getAttribute( 'data-x-text' ) || option.text,
       innerHTML: option.innerHTML,
       selected: option.selected,
       disabled: option.disabled,

--- a/src/slim-select/select.ts
+++ b/src/slim-select/select.ts
@@ -149,6 +149,12 @@ export class Select {
       })
     }
 
+    // add text attribute as data-x-text to the option element so that we
+    // can conserve it when re-constructing the data from option elements.
+    if ( info.text ) {
+      optionEl.setAttribute( 'data-x-text', info.text )
+    }
+
     return optionEl
   }
 }


### PR DESCRIPTION
When using the innerHTML option, the user-provided value for `text` was
getting dropped in favour of `innerHTML.text` when rebuilding the options
from the DOM.

This should resolve #105, #48 and #25 in a more intuitive way, without
breaking current behaviour too badly.

Note that the way I'm preserving the text value (by shoving it in a data 
attribute) is probably a bit hacky, but I couldn't find any persistent storage
for the option data that would survive the object -> OptionElement -> object
transitions.