### PR TITLE
Make default deselect label a mathematical symbol

### DIFF
--- a/src/slim-select/config.ts
+++ b/src/slim-select/config.ts
@@ -44,7 +44,7 @@ export class Config {
   public allowDeselect: boolean = false
   public allowDeselectOption: boolean = false
   public hideSelectedOption: boolean = false
-  public deselectLabel: string = 'x'
+  public deselectLabel: string = '×'
   public isEnabled: boolean = true
   public valuesUseText: boolean = false
   public showOptionTooltips: boolean = false


### PR DESCRIPTION
Sorry that I've not done all the compiling and minification - not sure how to do that.

The close symbol should be the mathematical × symbol, rather than a lowercase X as it is easier to style, typeset and (I think) accessibility (although could be wrong with that last one!) (Also, it looks better)

New: 

![image](https://user-images.githubusercontent.com/354085/61938708-a1b6c180-af89-11e9-9cd2-14387010206f.png)

Existing:

![image](https://user-images.githubusercontent.com/354085/61938722-a7140c00-af89-11e9-98c0-8964b1591bba.png)


Read more here: https://remysharp.com/2016/12/10/in-the-detail-close-button
