### PR TITLE
Alternative for display:none on select. Allows form validation.

### DIFF
--- a/src/slim-select/select.ts
+++ b/src/slim-select/select.ts
@@ -57,7 +57,8 @@ export class Select {
 
   public addAttributes() {
     this.element.tabIndex = -1
-    this.element.style.display = 'none'
+    /* this.element.style.display = 'none' */
+	this.element.classList.add("hidden-accessible");
 
     // Add slim select id
     this.element.dataset.ssid = this.main.config.id

--- a/src/slim-select/slim.ts
+++ b/src/slim-select/slim.ts
@@ -85,7 +85,7 @@ export class Slim {
     container.classList.add(this.main.config.id)
     container.classList.add(this.main.config.main)
     for (const c of this.main.config.class) {
-      if (c.trim() !== '') {
+      if (c.trim() !== '' && c.trim() !== 'hidden-accessible') {
         container.classList.add(c)
       }
     }

--- a/src/slim-select/slimselect.scss
+++ b/src/slim-select/slimselect.scss
@@ -390,3 +390,16 @@ $spacing-s: 4px !default;
     }
   }
 }
+
+.hidden-accessible {
+	border: 0 !important;
+	clip: rect(0 0 0 0) !important;
+	-webkit-clip-path: inset(50%) !important;
+	clip-path: inset(50%) !important;
+	height: 1px !important;
+	overflow: hidden !important;
+	padding: 0 !important;
+	position: absolute !important;
+	width: 1px !important;
+	white-space: nowrap !important;
+}


### PR DESCRIPTION
Hey. I experienced problems with standard jquery form validation, which is caused by your display:none on the select-tag. Form validation ignores hidden tags. Instead I replaced the display:none with adding the hidden-accessible class (stolen from select2) to the SELECT. This now allows for form validation.

I haven't re-compiled the vue-code since I do not have a proper setup for that.