### PR TITLE
Fix open options in 'above' state

### DIFF
--- a/src/slim-select/helper.ts
+++ b/src/slim-select/helper.ts
@@ -36,12 +36,12 @@ export function ensureElementInView(container: HTMLElement, element: HTMLElement
 
 export function putContent(el: HTMLElement, currentPosition: string, isOpen: boolean): string {
   const height = el.offsetHeight
-  const rect = el.getBoundingClientRect()
-  const elemTop = (isOpen ? rect.top : rect.top - height)
-  const elemBottom = (isOpen ? rect.bottom : rect.bottom + height)
+  const rect = el.parentNode.getBoundingClientRect()
+  const elemTop = rect.top - height
+  const elemBottom = rect.bottom + height
 
   if (elemTop <= 0) { return 'below' }
-  if (elemBottom >= window.innerHeight) { return 'above' }
+  if (elemBottom >= window.innerHeight - 20) /* can be scroll at window bottom */ { return 'above' }
   return (isOpen ? currentPosition : 'below')
 }
 


### PR DESCRIPTION
If you open select form closed state it is `isOpen` as false and do some odd calculation like:
```
  const height = el.offsetHeight
  const rect = el.getBoundingClientRect()
  const elemTop = (isOpen ? rect.top : rect.top - height)
  const elemBottom = (isOpen ? rect.bottom : rect.bottom + height)
```
If you get element `offsetHeight` then it included in result `getBoundingClientRect` so add or substract produce not what you are expected.

For example I make debugger stop and got next pictures in FF 69.0.3:
![scr_1571749004](https://user-images.githubusercontent.com/53032556/67291923-f3b8a600-f4ea-11e9-97c6-b1e3cc660c84.png)
![scr_1571749018](https://user-images.githubusercontent.com/53032556/67291940-f915f080-f4ea-11e9-90d1-c63767081416.png)
![scr_1571749039](https://user-images.githubusercontent.com/53032556/67291951-fc10e100-f4ea-11e9-9c6c-6e6463fd52ef.png)

On this screens `isOpen` is false, but block already visible.

So I change code for proper work regardless open/close state.   
We get `getBoundingClientRect` for parent and height of options block. Now we can calculate `elemTop` as top for display content 'above' and `elemBottom` as bottom for display content 'below'.

Also I add gap with 20px for check 'below' overflow-y, because you never exactly know about scroll bar - it can be stay, for example.
