### PR TITLE
Disable autocorrect in iOS

### DIFF
--- a/src/slim-select/slim.ts
+++ b/src/slim-select/slim.ts
@@ -358,6 +358,9 @@ export class Slim {
     input.placeholder = this.main.config.searchPlaceholder
     input.tabIndex = 0
     input.setAttribute('aria-label', this.main.config.searchPlaceholder)
+    input.setAttribute('autocapitalize', 'off')
+    input.setAttribute('autocomplete', 'off')
+    input.setAttribute('autocorrect', 'off')
     input.onclick = (e) => {
       setTimeout(() => {
         const target = e.target as HTMLInputElement


### PR DESCRIPTION
When using the component in Safari on iOS with its default keyboard, the autocorrect pop-up might be rendered below the input field. A common suggestion for preventing that is to set the three attributes (`autocapitalize`, `autocomplete`, and `autocorrect`) to `off`.

In this PR I hardcoded the three attributes to always be added. Since the component is a dropdown, I don't think there's a scenario in which one would want the autocorrect pop-up to appear, so there's probably no need to add an option to make it configurable.