### PR TITLE
addToBody fix: dropdown closing after clicking on input on touch devices

### DIFF
--- a/src/slim-select/slim.ts
+++ b/src/slim-select/slim.ts
@@ -56,6 +56,10 @@ export class Slim {
       this.container.appendChild(this.singleSelected.container)
     }
     if (this.main.config.addToBody) {
+      // add the id to the content as a class as well
+      // this is important on touch devices as the close method is
+      // triggered when clicks on the document body occur
+      this.content.classList.add(this.main.config.id)
       document.body.appendChild(this.content)
     } else {
       this.container.appendChild(this.content)


### PR DESCRIPTION
This happened because the close method is being triggered when something is clicked on the document body.
Fix by simply adding the id to the content when it's added to the document body