### PR TITLE
Fixed createOption method

### DIFF
--- a/src/slim-select/helper.ts
+++ b/src/slim-select/helper.ts
@@ -90,6 +90,16 @@ export function highlight(str: string, search: any, className: string) {
   return completedString
 }
 
+export function kebabCase(str: string) {
+  const result = str.replace(
+    /[A-Z\u00C0-\u00D6\u00D8-\u00DE]/g,
+    match => '-' + match.toLowerCase()
+  )
+  return (str[0] === str[0].toUpperCase())
+    ? result.substring(1)
+    : result
+}
+
 // Custom events
 (() => {
   const w = (window as any)

--- a/src/slim-select/select.ts
+++ b/src/slim-select/select.ts
@@ -1,5 +1,6 @@
 import SlimSelect from './index'
 import { Option, Optgroup, dataArray } from './data'
+import { kebabCase } from './helper'
 
 interface Constructor {
   select: HTMLSelectElement
@@ -133,7 +134,7 @@ export class Select {
 
   public createOption(info: any): HTMLOptionElement {
     const optionEl = document.createElement('option')
-    optionEl.value = info.value || info.text
+    optionEl.value = info.value !== '' ? info.value : info.text
     optionEl.innerHTML = info.innerHTML || info.text
     if (info.selected) { optionEl.selected = info.selected }
     if (info.disabled) { optionEl.disabled = true }
@@ -145,7 +146,7 @@ export class Select {
     }
     if (info.data && typeof info.data === 'object') {
       Object.keys(info.data).forEach((key) => {
-        optionEl.setAttribute('data-' + key, info.data[key])
+        optionEl.setAttribute('data-' + kebabCase(key), info.data[key])
       })
     }
 


### PR DESCRIPTION
- Allowed the '0' string to be a valid value for an option, only the empty string will trigger the fallback on the text
- Fixed the creation of the data attributes of an option element to allow kebab cased attributes (previously, a data object like { helloWorld: '0' } would be converted to a data-helloworld="0" attribute instead of the correct data-hello-world="0")