### PR TITLE
Fix deselect button appearing when there are no options.

### DIFF
--- a/src/slim-select/index.ts
+++ b/src/slim-select/index.ts
@@ -152,7 +152,7 @@ export default class SlimSelect {
     return select
   }
 
-  public selected(): string | string[] {
+  public selected(): string | string[] | undefined {
     if (this.config.isMultiple) {
       const selected = this.data.getSelected() as Option[]
       const outputSelected: string[] = []
@@ -162,7 +162,7 @@ export default class SlimSelect {
       return outputSelected
     } else {
       const selected = this.data.getSelected() as Option
-      return (selected ? selected.value as string : '')
+      return (selected ? selected.value : '')
     }
   }
 

--- a/src/slim-select/slim.ts
+++ b/src/slim-select/slim.ts
@@ -180,7 +180,8 @@ export class Slim {
         return
       }
 
-      if (this.main.selected() === '') {
+      const selectedValue = this.main.selected()
+      if (selectedValue === '' || selectedValue === undefined) {
         this.singleSelected.deselect.classList.add('ss-hide')
       } else {
         this.singleSelected.deselect.classList.remove('ss-hide')


### PR DESCRIPTION
An incorrect type assertion ignored the possibility that Option.value is
undefined. (which can happen if the <select> element has no options)

Other solutions are of course possible (ideally the type assertions would be
made unnecessary altogether). But this fix seems quick and simple and unable
to break anything else.

Fixes #242.