### PR TITLE
Fix assigning value to new created option.

### DIFF
--- a/src/slim-select/select.ts
+++ b/src/slim-select/select.ts
@@ -315,7 +315,7 @@ export default class Select {
 
   public createOption(info: Option): HTMLOptionElement {
     const optionEl = document.createElement('option')
-    optionEl.value = info.value !== '' ? info.value : info.text
+    optionEl.value = info.value
     optionEl.innerHTML = info.html || info.text
     if (info.selected) {
       optionEl.selected = info.selected


### PR DESCRIPTION
Assign value to new created option. We dont want to assign option text if option value blank. https://github.com/brianvoe/slim-select/issues/378