### PR TITLE
Change "main" in package.json to an existing target

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/brianvoe/slim-select/issues"
   },
   "type": "module",
-  "main": "dist/slimselect.ssr.js",
+  "main": "dist/slimselect.umd.js",
   "browser": "dist/slimselect.umd.js",
   "module": "dist/slimselect.es.js",
   "unpkg": "dist/slimselect.umd.min.js",


### PR DESCRIPTION
The ssr file doesn't exist in dist, causing jest to fail to load the module. This fixes it.