### PR TITLE
webpack 5: export 'default' (imported as 'SlimSelect') was not found in 'slim-select'

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "url": "https://github.com/brianvoe/slim-select/issues"
   },
   "type": "module",
-  "main": "dist/slimselect.ssr.js",
-  "browser": "dist/slimselect.umd.js",
+  "main": "dist/slimselect.js",
   "module": "dist/slimselect.es.js",
   "unpkg": "dist/slimselect.umd.min.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
1. `main` exports a non-existent file `dist/slimselect.ssr.js`
2. bundlers (in my case webpack 5) [prefer the browser entry point over everything else][0] so having that export returning a umd build will break imports ala

```js
import SlimSelect from 'slim-select'
```

the better alternative seems to be to 
- return a umd build from main
- return an esm build from module
- remove `browser`

as it currently is, wepack will try to import `SlimSelect` from `dist/slimselect.umd.js` which is no esm and has no exports thus failing with:

```
export 'default' (imported as 'SlimSelect') was not found in 'slim-select' (module has no exports)
```

this pr fixes the import/export.

now, i don't understand why the "browser" entry point was added in 9b6e9fa in the first place so i'm not sure what this will break.

related: #269.

[0]: https://webpack.js.org/configuration/resolve/#resolvemainfields