### PR TITLE
restore style inheritance from original select

### DIFF
--- a/src/slim-select/render.ts
+++ b/src/slim-select/render.ts
@@ -194,6 +194,7 @@ export default class Render {
 
     // Add styles
     if (this.settings.style !== '') {
+      this.main.main.style.cssText = this.settings.style
       this.content.main.style.cssText = this.settings.style
     }
 


### PR DESCRIPTION
fixes #412

main use case for me is setting a width to the original select and have it respect that