### PR TITLE
Make CSS classes overridable during initialization

### DIFF
--- a/src/docs/app.vue
+++ b/src/docs/app.vue
@@ -62,6 +62,7 @@ export default defineComponent({
           closable: 'close',
           options: [
             { text: 'select', value: 'settings#select' },
+            { text: 'cssClasses', value: 'settings#cssClasses' },
             { text: 'alwaysOpen', value: 'settings#alwaysOpen' },
             { text: 'contentLocation', value: 'settings#contentLocation' },
             { text: 'contentPosition', value: 'settings#contentPosition' },

--- a/src/docs/pages/settings/css_classes.vue
+++ b/src/docs/pages/settings/css_classes.vue
@@ -1,0 +1,81 @@
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+import SlimSelect from '../../../slim-select'
+
+export default defineComponent({
+    name: 'CustomCss',
+    mounted() {
+        new SlimSelect({ select: this.$refs.mainSelect as HTMLSelectElement, cssClasses: { option: 'primary-option' } })
+        new SlimSelect({ select: this.$refs.secondarySelect as HTMLSelectElement, cssClasses: { option: 'secondary-option' } })
+    },
+})
+</script>
+
+<style lang="scss">
+    .primary-option, .secondary-option {
+        padding: 0.25rem 0.5rem;
+        cursor: pointer;
+    }
+    .primary-option {
+        color: var(--ss-bg-color);
+        background: var(--ss-primary-color);
+        
+        &:hover {
+            color: var(--ss-primary-color);
+            background: var(--ss-bg-color);
+        }
+    }
+    .secondary-option {
+        color: var(--ss-primary-color);
+        background: var(--ss-bg-color);
+        
+        &:hover {
+            color: var(--ss-bg-color);
+            background: var(--ss-primary-color);
+        }
+    }
+    
+</style>
+
+<template>
+  <div id="cssClasses" class="content">
+      <h2 class="header">cssClasses</h2>
+      <p>
+      You can override the default CSS classes by setting them during initialization.
+      </p>
+
+      <div class="row">
+          <select ref="mainSelect">
+              <option value="value1">Value 1</option>
+              <option value="value2">Value 2</option>
+              <option value="value3">Value 3</option>
+          </select>
+          <select ref="secondarySelect">
+              <option value="value1">Value 1</option>
+              <option value="value2">Value 2</option>
+              <option value="value3">Value 3</option>
+          </select>
+      </div>
+
+      <pre>
+          <code class="language-html">
+          &lt;select id="primary-select"&gt;
+            &lt;option value="value1"&gt;Value 1&lt;/option&gt;
+            &lt;option value="value2"&gt;Value 2&lt;/option&gt;
+            &lt;option value="value3"&gt;Value 3&lt;/option&gt;
+          &lt;/select&gt;
+          </code>
+      </pre>
+      
+      <pre>
+        <code class="language-javascript">
+          new SlimSelect({
+            select: '#primary-select',
+            cssClasses: {
+              option: "primary-option" 
+          })
+        </code>
+      </pre>
+  </div>
+</template>

--- a/src/docs/pages/settings/index.vue
+++ b/src/docs/pages/settings/index.vue
@@ -8,6 +8,7 @@ import CloseOnSelect from './close_on_select.vue'
 import ContentLocation from './content_location.vue'
 import ContentPosition from './content_position.vue'
 import Css from './css.vue'
+import CssClasses from './css_classes.vue'
 import DataAttributes from './data_attributes.vue'
 import Deselect from './deselect.vue'
 import Disabled from './disabled.vue'
@@ -30,6 +31,7 @@ export default defineComponent({
   name: 'Settings',
   components: {
     Select,
+    CssClasses,
     AlwaysOpen,
     ContentLocation,
     ContentPosition,
@@ -59,6 +61,7 @@ export default defineComponent({
 <template>
   <div id="settings" class="contents">
     <Select />
+    <CssClasses />
     <AlwaysOpen />
     <ContentLocation />
     <ContentPosition />

--- a/src/slim-select/css_classes.ts
+++ b/src/slim-select/css_classes.ts
@@ -1,0 +1,111 @@
+export type CssClassesPartial = Partial<CssClasses>
+
+export default class CssClasses {
+    public main: string
+    // Placeholder
+    public placeholder: string
+
+    // Values
+    public values: string
+    public single: string
+    public max: string
+    public value: string
+    public valueText: string
+    public valueDelete: string
+    public valueOut: string
+
+    // Deselect
+    public deselect: string
+    public deselectPath: string // Not a class but whatever
+
+    // Arrow
+    public arrow: string
+    public arrowClose: string // Not a class but whatever
+    public arrowOpen: string // Not a class but whatever
+
+    // Content
+    public content: string
+    public openAbove: string
+    public openBelow: string
+
+    // Search
+    public search: string
+    public searchHighlighter: string
+    public searching: string
+    public addable: string
+    public addablePath: string // Not a class but whatever
+
+    // List optgroups/options
+    public list: string
+
+    // Optgroup
+    public optgroup: string
+    public optgroupLabel: string
+    public optgroupLabelText: string
+    public optgroupActions: string
+    public optgroupSelectAll: string // optgroup select all
+    public optgroupSelectAllBox: string // Not a class but whatever
+    public optgroupSelectAllCheck: string // Not a class but whatever
+    public optgroupClosable: string
+
+    // Option
+    public option: string
+    public optionDelete: string // Not a class but whatever
+    public highlighted: string
+
+    // Misc
+    public open: string
+    public close: string
+    public selected: string
+    public error: string
+    public disabled: string
+    public hide: string
+    
+    constructor(classes?: CssClassesPartial) {
+        if (!classes) {
+            classes = {}
+        }
+        
+        this.main = classes.main || 'ss-main'
+        this.placeholder = classes.placeholder || 'ss-placeholder'
+        this.values = classes.values || 'ss-values'
+        this.single = classes.single || 'ss-single'
+        this.max = classes.max || 'ss-max'
+        this.value = classes.value || 'ss-value'
+        this.valueText = classes.valueText || 'ss-value-text'
+        this.valueDelete = classes.valueDelete || 'ss-value-delete'
+        this.valueOut = classes.valueOut || 'ss-value-out'
+
+        this.deselect = classes.deselect || 'ss-deselect'
+        this.deselectPath = classes.deselectPath || 'M10,10 L90,90 M10,90 L90,10'
+        this.arrow = classes.arrow || 'ss-arrow'
+        this.arrowClose = classes.arrowClose || 'M10,30 L50,70 L90,30'
+        this.arrowOpen = classes.arrowOpen || 'M10,70 L50,30 L90,70'
+        this.content = classes.content || 'ss-content'
+        this.openAbove = classes.openAbove || 'ss-open-above'
+        this.openBelow = classes.openBelow || 'ss-open-below'
+        this.search = classes.search ||  'ss-search'
+        this.searchHighlighter = classes.searchHighlighter || 'ss-search-highlight'
+        this.searching = classes.searching || 'ss-searching'
+        this.addable = classes.addable || 'ss-addable'
+        this.addablePath = classes.addablePath || 'M50,10 L50,90 M10,50 L90,50'
+        this.list = classes.list || 'ss-list'
+        this.optgroup = classes.optgroup || 'ss-optgroup'
+        this.optgroupLabel = classes.optgroupLabel || 'ss-optgroup-label'
+        this.optgroupLabelText = classes.optgroupLabelText || 'ss-optgroup-label-text'
+        this.optgroupActions = classes.optgroupActions || 'ss-optgroup-actions'
+        this.optgroupSelectAll = classes.optgroupSelectAll || 'ss-selectall'
+        this.optgroupSelectAllBox = classes.optgroupSelectAllBox || 'M60,10 L10,10 L10,90 L90,90 L90,50'
+        this.optgroupSelectAllCheck = classes.optgroupSelectAllCheck || 'M30,45 L50,70 L90,10'
+        this.optgroupClosable = classes.optgroupClosable || 'ss-closable'
+        this.option = classes.option || 'ss-option'
+        this.optionDelete = classes.optionDelete || 'M10,10 L90,90 M10,90 L90,10'
+        this.highlighted = classes.highlighted || 'ss-highlighted'
+        this.open = classes.open || 'ss-open'
+        this.close = classes.close || 'ss-close'
+        this.selected = classes.selected || 'ss-selected'
+        this.error = classes.error || 'ss-error'
+        this.disabled = classes.disabled || 'ss-disabled'
+        this.hide = classes.hide || 'ss-hide'
+    }
+}

--- a/src/slim-select/index.ts
+++ b/src/slim-select/index.ts
@@ -3,11 +3,13 @@ import Render from './render'
 import Select from './select'
 import Settings, { SettingsPartial } from './settings'
 import Store, { DataArray, DataArrayPartial, Option, OptionOptional } from './store'
+import CssClasses, { CssClassesPartial } from './css_classes'
 
 export interface Config {
   select: string | Element
   data?: DataArrayPartial
-  settings?: SettingsPartial
+  settings?: SettingsPartial,
+  cssClasses?: CssClassesPartial,
   events?: Events
 }
 
@@ -29,6 +31,7 @@ export default class SlimSelect {
 
   // Classes
   public settings!: Settings
+  public cssClasses!: CssClasses
   public select!: Select
   public store!: Store
   public render!: Render
@@ -73,6 +76,9 @@ export default class SlimSelect {
 
     // Set settings
     this.settings = new Settings(config.settings)
+
+    // Set CSS classes
+    this.cssClasses = new CssClasses(config.cssClasses)
 
     // Set events
     const debounceEvents = ['afterChange', 'beforeOpen', 'afterOpen', 'beforeClose', 'afterClose']
@@ -149,7 +155,7 @@ export default class SlimSelect {
     }
 
     // Setup render class
-    this.render = new Render(this.settings, this.store, renderCallbacks)
+    this.render = new Render(this.settings, this.cssClasses, this.store, renderCallbacks)
     this.render.renderValues()
     this.render.renderOptions(this.store.getData())
 

--- a/src/slim-select/render.test.ts
+++ b/src/slim-select/render.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from '@jest/globals'
 import Render, { Callbacks } from './render'
 import Settings from './settings'
 import Store, { DataArray, Option } from './store'
+import CssClasses from './css_classes'
 
 describe('select module', () => {
   test('constructor', () => {
@@ -19,6 +20,7 @@ describe('select module', () => {
 
     // default settings
     const settings = new Settings()
+    const classes = new CssClasses()
 
     // default callbacks
     const callbacks = {
@@ -33,7 +35,7 @@ describe('select module', () => {
       },
     } as Callbacks
 
-    const render = new Render(settings, store, callbacks)
+    const render = new Render(settings, classes, store, callbacks)
     expect(render).toBeInstanceOf(Render)
   })
 })

--- a/src/slim-select/render.ts
+++ b/src/slim-select/render.ts
@@ -1,6 +1,7 @@
 import { debounce } from './helpers'
 import Settings from './settings'
 import Store, { DataArray, Optgroup, Option, OptionOptional } from './store'
+import CssClasses from './css_classes'
 
 export interface Callbacks {
   open: () => void
@@ -53,73 +54,12 @@ export default class Render {
   public content: Content
 
   // Classes
-  public classes = {
-    // Main
-    main: 'ss-main',
+  public classes: CssClasses
 
-    // Placeholder
-    placeholder: 'ss-placeholder',
-
-    // Values
-    values: 'ss-values',
-    single: 'ss-single',
-    max: 'ss-max',
-    value: 'ss-value',
-    valueText: 'ss-value-text',
-    valueDelete: 'ss-value-delete',
-    valueOut: 'ss-value-out',
-
-    // Deselect
-    deselect: 'ss-deselect',
-    deselectPath: 'M10,10 L90,90 M10,90 L90,10', // Not a class but whatever
-
-    // Arrow
-    arrow: 'ss-arrow',
-    arrowClose: 'M10,30 L50,70 L90,30', // Not a class but whatever
-    arrowOpen: 'M10,70 L50,30 L90,70', // Not a class but whatever
-
-    // Content
-    content: 'ss-content',
-    openAbove: 'ss-open-above',
-    openBelow: 'ss-open-below',
-
-    // Search
-    search: 'ss-search',
-    searchHighlighter: 'ss-search-highlight',
-    searching: 'ss-searching',
-    addable: 'ss-addable',
-    addablePath: 'M50,10 L50,90 M10,50 L90,50', // Not a class but whatever
-
-    // List optgroups/options
-    list: 'ss-list',
-
-    // Optgroup
-    optgroup: 'ss-optgroup',
-    optgroupLabel: 'ss-optgroup-label',
-    optgroupLabelText: 'ss-optgroup-label-text',
-    optgroupActions: 'ss-optgroup-actions',
-    optgroupSelectAll: 'ss-selectall', // optgroup select all
-    optgroupSelectAllBox: 'M60,10 L10,10 L10,90 L90,90 L90,50', // Not a class but whatever
-    optgroupSelectAllCheck: 'M30,45 L50,70 L90,10', // Not a class but whatever
-    optgroupClosable: 'ss-closable',
-
-    // Option
-    option: 'ss-option',
-    optionDelete: 'M10,10 L90,90 M10,90 L90,10', // Not a class but whatever
-    highlighted: 'ss-highlighted',
-
-    // Misc
-    open: 'ss-open',
-    close: 'ss-close',
-    selected: 'ss-selected',
-    error: 'ss-error',
-    disabled: 'ss-disabled',
-    hide: 'ss-hide',
-  }
-
-  constructor(settings: Required<Settings>, store: Store, callbacks: Callbacks) {
+  constructor(settings: Required<Settings>, classes: Required<CssClasses>, store: Store, callbacks: Callbacks) {
     this.store = store
     this.settings = settings
+    this.classes = classes
     this.callbacks = callbacks
 
     this.main = this.mainDiv()


### PR DESCRIPTION
Add a setting for overriding CSS classes. Because of the use of `classList.add()`, only a single class can be set currently. It might be worth it to refactor it so several classes can be used (this would be useful for people who use atomic CSS frameworks like Tailwind).

This PR solves #522 