### PR TITLE
Allow key presses not relevant to SlimSelect to propagate to default handlers

### DIFF
--- a/src/slim-select/render.ts
+++ b/src/slim-select/render.ts
@@ -265,7 +265,7 @@ export default class Render {
           return false
       }
 
-      return false
+      return true
     }
 
     // Add onclick for main div


### PR DESCRIPTION
While the main div has focus, it soaks up all `onkeydown` events. Those it recognizes (arrow keys, tab, space, enter, etc) are dispatched to its event handlers, but all unrecognized key events are dropped and prevented from propagating.

This means, while the select box has focus:

* cmd+R no longer reloads the window
* cmd-left no longer goes to the previous page
* cmd+F stops bringing up the find-in-page bar
* cmd+H stops showing the history window
* cmd+P stops bring up the print dialog
* page-up and page-down don't scroll, home and end don't go to the top and bottom of the page
* probably others

Instead, all these standard keyboard shortcuts have no effect until the main div is unfocused, which is pretty confusing and annoying behavior. Accessibility issues aside, as a user, if the last thing I did was select an option from a slim-select, my "reload page" keyboard shortcut appears broken for no obvious reason.

This small change from `return false` to `return true` lets keyboard events bubble up to their default browser handlers.

Note: I'm on OSX and have tried Firefox and Chrome with identical results. Other browsers or operating systems may do a better job at disallowing in-page event handlers from blocking fundamental features like "Reload".


---

<strike>Just noticed this fixes #526</strike> I misinterpreted that issue, this PR does not fix it.