### PR TITLE
Update paths to type declaration files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     ".": {
       "import": "./dist/slimselect.js",
       "require": "./dist/slimselect.umd.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": {
       "types": "./dist/*.d.ts"
     },
     "./styles": "./dist/slimselect.css"


### PR DESCRIPTION
I was battling my monorepo setup and almost got everything to work except importing slim-select. I was getting an error:
```
Could not find a declaration file for module 'slim-select'. '/Users/jack/Code/monkeytype/node_modules/slim-select/dist/slimselect.js' implicitly has an 'any' type.
  There are types at '/Users/jack/Code/monkeytype/node_modules/slim-select/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'slim-select' library may need to update its package.json or typings.ts(7016)
  ```

which said there are type definitions but could not be resolved due to the `exports` property. I decided to have a look and the `types` key was defined incorrectly (im pretty sure the `*` syntax cannot be used inside the `"."` key). I updated the path to `./dist/index.d.ts` and everything works great.



I also added a `./*` export which allows you to import any of the other types like so:

![image](https://github.com/user-attachments/assets/487bfaaf-dde8-4305-a8f8-591d759247b5)


Fully resolves #462