### PR TITLE
Add optgroup to search filter callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ new SlimSelect({
 
   events: {
     search: (searchValue: string, currentData: DataArray) => Promise<DataArrayPartial> | DataArrayPartial
-    searchFilter: (option: Option, search: string) => boolean
+    searchFilter: (option: Option, search: string, optgroup: Optgroup | null) => boolean
     addable: (value: string) => Promise<OptionOptional | string> | OptionOptional | string | Error
     beforeChange: (newVal: Option[], oldVal: Option[]) => boolean | void
     afterChange: (newVal: Option[]) => void

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ new SlimSelect({
     searchText: 'No Results',
     searchingText: 'Searching...',
     searchHighlight: false,
+    searchHighlightGroups: false,
     closeOnSelect: true,
     contentLocation: document.body,
     contentPosition: 'absolute',

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2,7 +2,7 @@ import CssClasses from './classes';
 import Render from './render';
 import Select from './select';
 import Settings, { SettingsPartial } from './settings';
-import Store, { DataArray, DataArrayPartial, Option, OptionOptional } from './store';
+import Store, { DataArray, DataArrayPartial, Optgroup, Option, OptionOptional } from './store';
 export interface Config {
     select: string | Element;
     data?: DataArrayPartial;
@@ -12,7 +12,7 @@ export interface Config {
 }
 export interface Events {
     search?: (searchValue: string, currentData: DataArray) => Promise<DataArrayPartial> | DataArrayPartial;
-    searchFilter?: (option: Option, search: string) => boolean;
+    searchFilter?: (option: Option, search: string, optgroup: Optgroup | null) => boolean;
     addable?: (value: string) => Promise<OptionOptional | string> | OptionOptional | string | false | null | undefined | Error;
     beforeChange?: (newVal: Option[], oldVal: Option[]) => boolean | void;
     afterChange?: (newVal: Option[]) => void;

--- a/dist/settings.d.ts
+++ b/dist/settings.d.ts
@@ -16,6 +16,7 @@ export default class Settings {
     searchText: string;
     searchingText: string;
     searchHighlight: boolean;
+    searchHighlightGroups: boolean;
     closeOnSelect: boolean;
     contentLocation: HTMLElement;
     contentPosition: 'relative' | 'absolute';

--- a/src/docs/pages/events/search_filter.vue
+++ b/src/docs/pages/events/search_filter.vue
@@ -60,7 +60,7 @@ export default defineComponent({
         searchHighlight: true
       },
       events: {
-        searchFilter: (option: Option, search: string) => {
+        searchFilter: (option: Option, search: string, optgroup: Optgroup | null) => {
           return option.text.toLowerCase().includes(search.toLowerCase())
         }
       }
@@ -107,7 +107,7 @@ export default defineComponent({
         searchHighlight: true
       },
       events: {
-        searchFilter: (option: Option, search: string, optgroup: Optgroup) => {          
+        searchFilter: (option: Option, search: string, optgroup: Optgroup | null) => {          
           return option.text.toLowerCase().includes(search.toLowerCase()) ||
             optgroup.label.toLowerCase().includes(search.toLowerCase())
         }

--- a/src/docs/pages/events/search_filter.vue
+++ b/src/docs/pages/events/search_filter.vue
@@ -104,7 +104,8 @@ export default defineComponent({
         }
       ],
       settings: {
-        searchHighlight: true
+        searchHighlight: true,
+        searchHighlightGroups: true
       },
       events: {
         searchFilter: (option: Option, search: string, optgroup: Optgroup | null) => {          
@@ -147,6 +148,10 @@ export default defineComponent({
       <code class="language-javascript">
         new SlimSelect({
           select: '#selectElement',
+          settings: {
+            // Example 3: Show all options under matching option group
+            searchHighlightGroups: true
+          },
           events: {
             // Example: Exact case sensitive start of string match
             searchFilter: (option, search, optgroup) => {
@@ -158,7 +163,7 @@ export default defineComponent({
               return option.text.toLowerCase().indexOf(search.toLowerCase()) !== -1
             }
 
-            // Example: Show all options under matching option group
+            // Example 3: Show all options under matching option group
             searchFilter: (option, search, optgroup) => {
               return option.text.toLowerCase().includes(search.toLowerCase()) ||
                 optgroup.label.toLowerCase().includes(search.toLowerCase())

--- a/src/docs/pages/events/search_filter.vue
+++ b/src/docs/pages/events/search_filter.vue
@@ -2,7 +2,7 @@
 import { defineComponent } from 'vue'
 
 import SlimSelect from '../../../slim-select'
-import { Option } from '../../../slim-select/store'
+import { Option, Optgroup } from '../../../slim-select/store'
 
 export default defineComponent({
   name: 'SearchFilter',
@@ -13,7 +13,7 @@ export default defineComponent({
         searchHighlight: true
       },
       events: {
-        searchFilter: (option: Option, search: string) => {
+        searchFilter: (option: Option, search: string, optgroup: Optgroup | null) => {
           return option.text.toLowerCase().includes(search.toLowerCase())
         }
       }
@@ -65,6 +65,54 @@ export default defineComponent({
         }
       }
     })
+
+    new SlimSelect({
+      select: this.$refs.searchFilterMultipleIncludeOptgroup as HTMLSelectElement,
+      data: [
+        // List of foods seprated by optgroups
+        {
+          label: 'Fruits',
+          options: [
+            { text: 'Apple', value: 'apple' },
+            { text: 'Banana', value: 'banana' },
+            { text: 'Orange', value: 'orange' }
+          ]
+        },
+        {
+          label: 'Vegetables',
+          options: [
+            { text: 'Carrot', value: 'carrot' },
+            { text: 'Potato', value: 'potato' },
+            { text: 'Tomato', value: 'tomato' }
+          ]
+        },
+        {
+          label: 'Meats',
+          options: [
+            { text: 'Beef', value: 'beef' },
+            { text: 'Chicken', value: 'chicken' },
+            { text: 'Pork', value: 'pork' }
+          ]
+        },
+        {
+          label: 'Seafood',
+          options: [
+            { text: 'Crab', value: 'crab' },
+            { text: 'Lobster', value: 'lobster' },
+            { text: 'Shrimp', value: 'shrimp' }
+          ]
+        }
+      ],
+      settings: {
+        searchHighlight: true
+      },
+      events: {
+        searchFilter: (option: Option, search: string, optgroup: Optgroup) => {          
+          return option.text.toLowerCase().includes(search.toLowerCase()) ||
+            optgroup.label.toLowerCase().includes(search.toLowerCase())
+        }
+      }
+    })
   }
 })
 </script>
@@ -87,6 +135,12 @@ export default defineComponent({
         <option value="orange">Orange</option>
         <option value="pineapple">Pineapple</option>
       </select>
+
+      <select ref="searchFilterMultipleIncludeOptgroup">
+        <option value="apple">Apple</option>
+        <option value="orange">Orange</option>
+        <option value="pineapple">Pineapple</option>
+      </select>
     </div>
 
     <pre>
@@ -95,13 +149,19 @@ export default defineComponent({
           select: '#selectElement',
           events: {
             // Example: Exact case sensitive start of string match
-            searchFilter: (option, search) => {
+            searchFilter: (option, search, optgroup) => {
               return option.text.substr(0, search.length) === search
             }
 
             // Default
-            searchFilter: (option, search) => {
+            searchFilter: (option, search, optgroup) => {
               return option.text.toLowerCase().indexOf(search.toLowerCase()) !== -1
+            }
+
+            // Example: Show all options under matching option group
+            searchFilter: (option, search, optgroup) => {
+              return option.text.toLowerCase().includes(search.toLowerCase()) ||
+                optgroup.label.toLowerCase().includes(search.toLowerCase())
             }
           }
         })

--- a/src/docs/pages/events/search_filter.vue
+++ b/src/docs/pages/events/search_filter.vue
@@ -109,8 +109,15 @@ export default defineComponent({
       },
       events: {
         searchFilter: (option: Option, search: string, optgroup: Optgroup | null) => {          
-          return option.text.toLowerCase().includes(search.toLowerCase()) ||
-            optgroup.label.toLowerCase().includes(search.toLowerCase())
+          search = search.toLowerCase()
+
+          if (option.text.toLowerCase().includes(search))
+            return true
+          
+          if (optgroup && optgroup.label.toLowerCase().includes(search))
+            return true
+
+          return false
         }
       }
     })
@@ -165,8 +172,15 @@ export default defineComponent({
 
             // Example 3: Show all options under matching option group
             searchFilter: (option, search, optgroup) => {
-              return option.text.toLowerCase().includes(search.toLowerCase()) ||
-                optgroup.label.toLowerCase().includes(search.toLowerCase())
+              search = search.toLowerCase()
+
+              if (option.text.toLowerCase().includes(search))
+                return true
+              
+              if (optgroup && optgroup.label.toLowerCase().includes(search))
+                return true
+
+              return false
             }
           }
         })

--- a/src/docs/pages/settings/search.vue
+++ b/src/docs/pages/settings/search.vue
@@ -37,6 +37,13 @@ export default defineComponent({
         searchHighlight: true
       }
     })
+    new SlimSelect({
+      select: this.$refs.searchHighlightGroupSingle as HTMLSelectElement,
+      settings: {
+        searchHighlight: true,
+        searchHighlightGroup: true
+      }
+    })
 
     // Multiple
     new SlimSelect({
@@ -69,13 +76,20 @@ export default defineComponent({
         searchHighlight: true
       }
     })
+    new SlimSelect({
+      select: this.$refs.searchHighlightGroupMulti as HTMLSelectElement,
+      settings: {
+        searchHighlight: true,
+        searchHighlightGroup: true
+      }
+    })
   }
 })
 </script>
 
 <template>
   <div id="search" class="content">
-    <h2 class="header">showSearch / focusSearch / searchText / searchingText / searchHighlight</h2>
+    <h2 class="header">showSearch / focusSearch / searchText / searchingText / searchHighlight / searchHighlightGroups</h2>
     <p><b>showSearch</b> - is a boolean value that will decide whether or not to show the search. Default is true.</p>
     <p>
       <b>focusSearch</b> - is a boolean value that will decide whether or not to focus on the search on open. Default is
@@ -92,6 +106,10 @@ export default defineComponent({
       is 'Search'.
     </p>
     <p><b>searchHighlight</b> - is a boolean value that will highlight search results. Default is false.</p>
+    <p>
+      <b>searchHighlightGroups</b> - is a boolean value that will highlight matching groups when searching. 
+      Use when matching option group in searchFilter. Default is false.
+    </p>
 
     <div class="row" style="padding: 0 0 var(--spacing-half) 0">
       <select ref="showSearchSingle">
@@ -118,6 +136,18 @@ export default defineComponent({
         <option value="dog">Dog</option>
         <option value="cat">Cat</option>
         <option value="bird">Bird</option>
+      </select>
+      <select ref="searchHighlightGroupSingle">
+        <optgroup label="Animals">
+          <option value="dog">Dog</option>
+          <option value="cat">Cat</option>
+          <option value="bird">Bird</option>
+        </optgroup>
+        <optgroup label="Fruits">
+          <option value="apple">Apple</option>
+          <option value="banana">Banana</option>
+          <option value="orange">Orange</option>
+        </optgroup>
       </select>
     </div>
 
@@ -146,6 +176,18 @@ export default defineComponent({
         <option value="dog">Dog</option>
         <option value="cat">Cat</option>
         <option value="bird">Bird</option>
+      </select>
+      <select ref="searchHighlightGroupMulti" multiple>
+        <optgroup label="Animals">
+          <option value="dog">Dog</option>
+          <option value="cat">Cat</option>
+          <option value="bird">Bird</option>
+        </optgroup>
+        <optgroup label="Fruits">
+          <option value="apple">Apple</option>
+          <option value="banana">Banana</option>
+          <option value="orange">Orange</option>
+        </optgroup>
       </select>
     </div>
 

--- a/src/slim-select/index.ts
+++ b/src/slim-select/index.ts
@@ -3,7 +3,7 @@ import { debounce, hasClassInTree, isEqual } from './helpers'
 import Render from './render'
 import Select from './select'
 import Settings, { SettingsPartial } from './settings'
-import Store, { DataArray, DataArrayPartial, Option, OptionOptional } from './store'
+import Store, { DataArray, DataArrayPartial, Optgroup, Option, OptionOptional } from './store'
 
 export interface Config {
   select: string | Element
@@ -15,7 +15,7 @@ export interface Config {
 
 export interface Events {
   search?: (searchValue: string, currentData: DataArray) => Promise<DataArrayPartial> | DataArrayPartial
-  searchFilter?: (option: Option, search: string) => boolean
+  searchFilter?: (option: Option, search: string, optgroup: Optgroup | null) => boolean
   addable?: (
     value: string
   ) => Promise<OptionOptional | string> | OptionOptional | string | false | null | undefined | Error
@@ -41,7 +41,7 @@ export default class SlimSelect {
   // Events
   public events = {
     search: undefined,
-    searchFilter: (opt: Option, search: string) => {
+    searchFilter: (opt: Option, search: string, optgroup?: Optgroup) => {
       return opt.text.toLowerCase().indexOf(search.toLowerCase()) !== -1
     },
     addable: undefined,

--- a/src/slim-select/render.ts
+++ b/src/slim-select/render.ts
@@ -991,8 +991,13 @@ export default class Render {
         // Create label text div element
         const optgroupLabelText = document.createElement('div')
         optgroupLabelText.classList.add(this.classes.optgroupLabelText)
-        optgroupLabelText.textContent = d.label
+        optgroupLabelText.innerHTML = this.highlightText(
+          d.label,
+          this.content.search.input.value,
+          this.classes.searchHighlighter
+        )
         optgroupLabel.appendChild(optgroupLabelText)
+        
 
         // Create options container
         const optgroupActions = document.createElement('div')

--- a/src/slim-select/settings.ts
+++ b/src/slim-select/settings.ts
@@ -23,6 +23,7 @@ export default class Settings {
   public searchText: string
   public searchingText: string
   public searchHighlight: boolean
+  public searchHighlightGroups: boolean
   public closeOnSelect: boolean
   public contentLocation: HTMLElement
   public contentPosition: 'relative' | 'absolute'
@@ -57,6 +58,7 @@ export default class Settings {
     this.searchText = settings.searchText || 'No Results'
     this.searchingText = settings.searchingText || 'Searching...'
     this.searchHighlight = settings.searchHighlight !== undefined ? settings.searchHighlight : false
+    this.searchHighlightGroups = settings.searchHighlightGroups !== undefined ? settings.searchHighlightGroups : false
     this.closeOnSelect = settings.closeOnSelect !== undefined ? settings.closeOnSelect : true
     this.contentLocation = settings.contentLocation || document.body
     this.contentPosition = settings.contentPosition || 'absolute'

--- a/src/slim-select/store.ts
+++ b/src/slim-select/store.ts
@@ -273,7 +273,7 @@ export default class Store {
   }
 
   public getSelectedOptions(): Option[] {
-    return this.filter((opt: Option) => {
+    return this.filter((opt: Option, optgroup: Optgroup | null) => {
       return opt.selected
     }, false) as Option[]
   }
@@ -291,7 +291,7 @@ export default class Store {
   }
 
   public getOptionByID(id: string): Option | null {
-    let options = this.filter((opt: Option) => {
+    let options = this.filter((opt: Option, optgroup: Optgroup | null) => {
       return opt.id === id
     }, false) as Option[]
 
@@ -319,7 +319,7 @@ export default class Store {
   }
 
   // Take in search string and return filtered list of values
-  public search(search: string, searchFilter: (opt: Option, search: string) => boolean): DataArray {
+  public search(search: string, searchFilter: (opt: Option, search: string, optgroup: Optgroup | null) => boolean): DataArray {
     search = search.trim()
 
     // If search is empty, return all data
@@ -328,21 +328,22 @@ export default class Store {
     }
 
     // Run filter with search function
-    return this.filter((opt: Option): boolean => {
-      return searchFilter(opt, search)
+    return this.filter((opt: Option, optgroup: Optgroup | null): boolean => {
+      return searchFilter(opt, search, optgroup)
     }, true)
   }
 
   // Filter takes in a function that will be used to filter the data
   // This will also keep optgroups of sub options meet the filter requirements
-  public filter(filter: { (opt: Option): boolean } | null, includeOptgroup: boolean): DataArray {
+  public filter(filter: { (opt: Option, optgroup: Optgroup | null): boolean } | null, includeOptgroup: boolean): DataArray {
     const dataSearch: DataArray = []
     this.data.forEach((dataObj: DataObject) => {
       // Optgroup
       if (dataObj instanceof Optgroup) {
         let optOptions: Option[] = []
         dataObj.options.forEach((option: Option) => {
-          if (!filter || filter(option)) {
+          if (!filter || filter(option, dataObj)) {
+            console.log(dataObj)
             // If you dont want to include optgroups
             // just push to the dataSearch array
             if (!includeOptgroup) {
@@ -367,7 +368,7 @@ export default class Store {
 
       // Option
       if (dataObj instanceof Option) {
-        if (!filter || filter(dataObj)) {
+        if (!filter || filter(dataObj, null)) {
           dataSearch.push(new Option(dataObj))
         }
       }

--- a/src/slim-select/store.ts
+++ b/src/slim-select/store.ts
@@ -343,7 +343,6 @@ export default class Store {
         let optOptions: Option[] = []
         dataObj.options.forEach((option: Option) => {
           if (!filter || filter(option, dataObj)) {
-            console.log(dataObj)
             // If you dont want to include optgroups
             // just push to the dataSearch array
             if (!includeOptgroup) {


### PR DESCRIPTION
Including optgroup in the search filter callback allows for the use case where optgroup labels should be considered in the search criteria - e.g. showing all options under matching optgroups. 

Option group labels can now be highlighted when searching by setting settings.searchHighlightGroups to true.