### PR TITLE
Replaced right and left with logical properties in css

### DIFF
--- a/src/slim-select/slimselect.scss
+++ b/src/slim-select/slimselect.scss
@@ -93,12 +93,12 @@
   }
 
   &.ss-open-above {
-    border-top-left-radius: 0px;
-    border-top-right-radius: 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 0px;
   }
   &.ss-open-below {
-    border-bottom-left-radius: 0px;
-    border-bottom-right-radius: 0px;
+    border-end-start-radius: 0px;
+    border-end-end-radius: 0px;
   }
 
   .ss-values {
@@ -173,7 +173,7 @@
         width: var(--ss-spacing-l);
         padding: var(--ss-spacing-s) var(--ss-spacing-m);
         cursor: pointer;
-        border-left: solid 1px var(--ss-bg-color);
+        border-inline-start: solid 1px var(--ss-bg-color);
         box-sizing: content-box;
 
         svg {
@@ -266,16 +266,16 @@
     opacity: 1;
     transform: scaleY(1);
     transform-origin: center bottom;
-    border-top-left-radius: var(--ss-border-radius);
-    border-top-right-radius: var(--ss-border-radius);
+    border-start-start-radius: var(--ss-border-radius);
+    border-start-end-radius: var(--ss-border-radius);
   }
 
   &.ss-open-below {
     opacity: 1;
     transform: scaleY(1);
     transform-origin: center top;
-    border-bottom-left-radius: var(--ss-border-radius);
-    border-bottom-right-radius: var(--ss-border-radius);
+    border-end-start-radius: var(--ss-border-radius);
+    border-end-end-radius: var(--ss-border-radius);
   }
 
   .ss-search {
@@ -297,7 +297,7 @@
       border-radius: var(--ss-border-radius);
       background-color: var(--ss-bg-color);
       outline: 0;
-      text-align: left;
+      text-align: start;
       box-sizing: border-box;
 
       &::placeholder {


### PR DESCRIPTION
as there is good support for logical css properties in browsers, doing so will ensure consistent performance in and writing system and there is likely no need to include an rtl option in the settings

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values