### PR TITLE
Use `createDocumentFragment` to append options to DOM

### DIFF
--- a/src/slim-select/render.ts
+++ b/src/slim-select/render.ts
@@ -978,6 +978,7 @@ export default class Render {
     }
 
     // Append individual options to div container
+    const fragment = document.createDocumentFragment()
     for (const d of data) {
       // Create optgroup
       if (d instanceof Optgroup) {
@@ -1141,17 +1142,18 @@ export default class Render {
         // Loop through options
         for (const o of d.options) {
           optgroupEl.appendChild(this.option(o))
+          fragment.appendChild(optgroupEl)
         }
-
-        // Add optgroup to list
-        this.content.list.appendChild(optgroupEl)
       }
 
       // Create option
       if (d instanceof Option) {
-        this.content.list.appendChild(this.option(d as Option))
+        fragment.appendChild(this.option(d as Option))
       }
     }
+
+    // Append fragment to list
+    this.content.list.appendChild(fragment)
   }
 
   // Create option div element


### PR DESCRIPTION
I've bumped into a performance issue using slim-select when lots of options are repeatedly added/removed from the DOM as part of `renderOptions`.

We use the `search` event to query an endpoint that returns >7,000 records. This causes each option to be individually added/removed from the DOM, this can cause slowness for our application if a user searches multiple times. 

With this change, instead of adding each option to the DOM one-by-one and performing lots of modifications. We create a document fragment and append to that, once all options have been processed we append the document fragment to the DOM.

I'm working on benchmarking this to support the change but, anecdotally, I am seeing an improvement in responsiveness using this change locally.

Let me know if you have any concerns with this change 👍 