### PR TITLE
Fix the undefined `main.id` within the `updateAriaAttributes` function

### DIFF
--- a/src/slim-select/render.test.ts
+++ b/src/slim-select/render.test.ts
@@ -200,7 +200,7 @@ describe('render module', () => {
 
       expect(render.main.main.role).toBe('combobox')
       expect(render.main.main.getAttribute('aria-haspopup')).toBe('listbox')
-      expect(render.main.main.getAttribute('aria-controls')).toBe(render.content.main.id)
+      expect(render.main.main.getAttribute('aria-controls')).toBe(render.content.main.dataset.id ?? '')
       expect(render.main.main.getAttribute('aria-expanded')).toBe('false')
       expect(render.content.main.getAttribute('role')).toBe('listbox')
     })

--- a/src/slim-select/render.ts
+++ b/src/slim-select/render.ts
@@ -165,7 +165,7 @@ export default class Render {
   public updateAriaAttributes() {
     this.main.main.role = 'combobox'
     this.main.main.setAttribute('aria-haspopup', 'listbox')
-    this.main.main.setAttribute('aria-controls', this.content.main.id)
+    this.main.main.setAttribute('aria-controls', this.content.main.dataset.id ?? '')
     this.main.main.setAttribute('aria-expanded', 'false')
     this.content.main.setAttribute('role', 'listbox')
     // do an aria-labelledby here maybe


### PR DESCRIPTION
### Description

* fixes #592 

This line checks for `main.id` which has not been set as it has been commented out
https://github.com/brianvoe/slim-select/blob/000c023bf25c7901473d6a4a394587bdcd0ec41c/src/slim-select/render.ts#L168

It now correctly checks for the data-attribute that is set:
https://github.com/brianvoe/slim-select/blob/000c023bf25c7901473d6a4a394587bdcd0ec41c/src/slim-select/render.ts#L179-L180