### PR TITLE
Properly handle changes to options after the first rendering 

### DIFF
--- a/src/slim-select/index.test.ts
+++ b/src/slim-select/index.test.ts
@@ -1213,5 +1213,56 @@ describe('SlimSelect Module', () => {
 
       slim.destroy()
     })
+
+    test('should handle option change after first render', async () => {
+      // Test scenario: start with 2 options
+      document.body.innerHTML = `
+        <select id="test-select">
+          <option value="opt1">Option 1</option>
+          <option value="opt2">Option 2</option>
+        </select>
+      `
+
+      const selectElement = document.getElementById('test-select') as HTMLSelectElement
+      const slim = new SlimSelect({
+        select: selectElement
+      })
+
+      // Set an initial value
+      selectElement.value = 'opt2'
+
+      // Verify initial state
+      expect(selectElement.options.length).toBe(2)
+      expect(selectElement.value).toBe('opt2')
+      expect(slim.getData().length).toBe(2)
+
+      // Wait for all mutations to process
+      await new Promise((r) => setTimeout(r, 200))
+
+      // Rebuild options
+      document.getElementById('test-select')!.innerHTML = `
+        <option value="opt1">Option 1 updated</option>
+        <option value="opt2" selected>Option 2 updated</option>
+      `;
+
+      // Wait for all mutations to process
+      await new Promise((r) => setTimeout(r, 200))
+
+      // Verify options are still there
+      expect(selectElement.options.length).toBe(2)
+      expect(selectElement.options[0].textContent).toBe("Option 1 updated")
+      expect(selectElement.options[1].textContent).toBe("Option 2 updated")
+      expect(selectElement.value).toBe('opt2')
+
+      // Verify SlimSelect also has the options
+      const data = slim.getData()
+      expect(data.length).toBe(2)
+
+      // Verify selected value is empty
+      const selected = slim.getSelected()
+      expect(selected).toEqual(["opt2"])
+
+      slim.destroy()
+    })
   })
 })

--- a/src/slim-select/select.ts
+++ b/src/slim-select/select.ts
@@ -167,6 +167,7 @@ export default class Select {
     let classChanged = false
     let disabledChanged = false
     let optgroupOptionChanged = false
+    let selectionChanged = false;
 
     // Loop through mutations and check various things
     for (const m of mutations) {
@@ -186,7 +187,7 @@ export default class Select {
           for (const n of Array.from(m.addedNodes)) {
             if (n.nodeName === 'OPTION' && (<HTMLOptionElement>n).value === this.select.value) {
               // we added a new option that's now the select value
-              this.select.dispatchEvent(new Event('change'))
+              selectionChanged = true;
               break
             }
           }
@@ -227,12 +228,19 @@ export default class Select {
             this.pendingOptionsChange = currentData
           }
         }
+        if(selectionChanged) {
+          this.select.dispatchEvent(new Event('change'))
+        }
         return
       }
 
       this.changeListen(false)
       this.onOptionsChange(this.getData())
       this.changeListen(true)
+    }
+
+    if(selectionChanged) {
+      this.select.dispatchEvent(new Event('change'))
     }
   }
 


### PR DESCRIPTION
#646 fixes the value being lost when modifying a slimselect's original `<select>` DOM after creation, but slimselect still forgets the new options if you change through the DOM again them after slimselect picked them up

this PR adds a test for this behavior and fixes it by moving the change event to be fired after processing the option mutation.