### PR TITLE
Fix Shift+Click range selection ignoring search filter

### DIFF
--- a/src/slim-select/render.test.ts
+++ b/src/slim-select/render.test.ts
@@ -1557,6 +1557,56 @@ describe('render module', () => {
         opts[2].dispatchEvent(new MouseEvent('click', { shiftKey: true }))
         expect(closeMock).not.toHaveBeenCalled()
       })
+
+      test('Shift+Click with search filter selects only the filtered elements', async () => {
+        render.settings.showSearch = true
+        render.store = new Store('multiple', [
+          {
+            text: 'A0',
+            value: 'A0'
+          },
+          {
+            text: 'A1',
+            value: 'A1'
+          },
+          {
+            text: 'B0',
+            value: 'B0'
+          },
+          {
+            text: 'C0',
+            value: 'C0'
+          }
+        ])
+
+        render.renderValues()
+        render.renderOptions(render.store.getDataOptions())
+        let opts = render.getOptions(false, false, true)
+        expect(opts.length).toEqual(4)
+
+        // Simulate search
+        const searchFilter = (opt: Option, search: string): boolean => {
+          return opt.text.toLowerCase().indexOf(search.toLowerCase()) !== -1
+        }
+        const searchResults = render.store.search('0', searchFilter)
+        expect(searchResults).toHaveLength(3)
+        render.renderOptions(searchResults)
+
+        opts = render.getOptions(false, false, true)
+        expect(opts.length).toEqual(3)
+
+        // Click first option
+        opts[0].dispatchEvent(new MouseEvent('click'))
+        expect(afterChangeMock).toHaveBeenCalledWith([expect.objectContaining({ value: 'A0' })])
+
+        // Shift+Click third option - should select A0, B0, C0 and should not select A1
+        opts[2].dispatchEvent(new MouseEvent('click', { shiftKey: true }))
+        expect(afterChangeMock).toHaveBeenCalledWith([
+          expect.objectContaining({ value: 'A0' }),
+          expect.objectContaining({ value: 'B0' }),
+          expect.objectContaining({ value: 'C0' })
+        ])
+      })
     })
 
     describe('Combined modifier keys', () => {

--- a/src/slim-select/render.ts
+++ b/src/slim-select/render.ts
@@ -53,6 +53,7 @@ export default class Render {
 
   // Used to compute the range selection
   private lastSelectedOption: Option | null
+  private lastRenderedOptions: Option[]
 
   // Timeout tracking for cleanup
   private closeAnimationTimeout: ReturnType<typeof setTimeout> | null = null
@@ -70,6 +71,7 @@ export default class Render {
     this.classes = classes
     this.callbacks = callbacks
     this.lastSelectedOption = null
+    this.lastRenderedOptions = []
 
     this.main = this.mainDiv()
     this.content = this.contentDiv()
@@ -1088,6 +1090,10 @@ export default class Render {
 
   // Take in data and add options to
   public renderOptions(data: (Option | Optgroup)[]): void {
+    this.lastRenderedOptions = data
+      .map((o) => (o instanceof Option ? [o] : o.options.map((po) => new Option(po))))
+      .flat()
+
     // Clear out innerHtml
     this.content.list.innerHTML = ''
 
@@ -1419,7 +1425,7 @@ export default class Render {
 
         // Shift+Click: Select range from last clicked to current
         if (isShift && this.lastSelectedOption) {
-          const options = this.store.getDataOptions()
+          const options = this.lastRenderedOptions
           const lastIndex = options.findIndex((o: Option) => o.id === this.lastSelectedOption!.id)
           const currentIndex = options.findIndex((o: Option) => o.id === option.id)
 


### PR DESCRIPTION
Hi,
I'm the author of https://github.com/brianvoe/slim-select/pull/619 (Shift+Click range selection).

We are using this feature and we have found a bug: the Shift+Click selection ignores the active search filter and selects also the invisible elements that are in the range.

A simple example to reproduce this is the following:

```html
<select id="selectElement" multiple>
  <option>A0</option>
  <option>A1</option>
  <option>B0</option>
  <option>C0</option>
</select>

<script>
  new SlimSelect({
    select: '#selectElement'
  })
</script>
```

Then type "0" in the search filter and select elements from the first to the last. The element A1 is filtered out but is selected by the range selection:

<img width="300" height="229" alt="image" src="https://github.com/user-attachments/assets/3b3aa30a-1a24-43d7-b8ca-2b50ec23c5f8" />

This PR fixes this issue.

Thanks!