### PR TITLE
Documentation update

### DIFF
--- a/src/docs/pages/settings/max_values_shown.vue
+++ b/src/docs/pages/settings/max_values_shown.vue
@@ -57,6 +57,7 @@ export default defineComponent({
           settings: {
             maxValuesShown: 5, // Default 20
             maxValuesMessage: '{number} values selected', // Default '{number} selected'
+            allowDeselect: true, // necessary to allow deselection when summarised
           },
         });
       </pre>


### PR DESCRIPTION
The documentation for max values shows the example code, but it omits the allowDeselect option that is actually used in the page.

Without this option you cannot deselect an item in the dropdown by clicking on it, so you cannot deselect an item when in the summary state (max values shown is exceeded) as the individuals items currently selected are not shown.